### PR TITLE
Remove Payable Modifier 

### DIFF
--- a/src/periphery/LendgineRouter.sol
+++ b/src/periphery/LendgineRouter.sol
@@ -254,7 +254,7 @@ contract LendgineRouter is Multicall, Payment, SelfPermit, SwapHelper, IMintCall
   }
 
   /// @notice Take an option position and withdraw it fully into token1
-  function burn(BurnParams calldata params) external payable checkDeadline(params.deadline) returns (uint256 amount) {
+  function burn(BurnParams calldata params) external checkDeadline(params.deadline) returns (uint256 amount) {
     address lendgine = LendgineAddress.computeAddress(
       factory, params.token0, params.token1, params.token0Exp, params.token1Exp, params.upperBound
     );

--- a/src/periphery/LiquidityManager.sol
+++ b/src/periphery/LiquidityManager.sol
@@ -198,7 +198,7 @@ contract LiquidityManager is Multicall, Payment, SelfPermit, IPairMintCallback {
   }
 
   /// @notice Removes from a liquidity position
-  function removeLiquidity(RemoveLiquidityParams calldata params) external payable checkDeadline(params.deadline) {
+  function removeLiquidity(RemoveLiquidityParams calldata params) external checkDeadline(params.deadline) {
     address lendgine = LendgineAddress.computeAddress(
       factory, params.token0, params.token1, params.token0Exp, params.token1Exp, params.upperBound
     );
@@ -227,7 +227,7 @@ contract LiquidityManager is Multicall, Payment, SelfPermit, IPairMintCallback {
   }
 
   /// @notice Collects interest owed to the callers liqudity position
-  function collect(CollectParams calldata params) external payable returns (uint256 amount) {
+  function collect(CollectParams calldata params) external returns (uint256 amount) {
     ILendgine(params.lendgine).accruePositionInterest();
 
     address recipient = params.recipient == address(0) ? address(this) : params.recipient;

--- a/src/periphery/Payment.sol
+++ b/src/periphery/Payment.sol
@@ -22,7 +22,7 @@ abstract contract Payment {
     require(msg.sender == weth, "Not WETH9");
   }
 
-  function unwrapWETH(uint256 amountMinimum, address recipient) public payable {
+  function unwrapWETH(uint256 amountMinimum, address recipient) public {
     uint256 balanceWETH = Balance.balance(weth);
     if (balanceWETH < amountMinimum) revert InsufficientOutputError();
 
@@ -32,7 +32,7 @@ abstract contract Payment {
     }
   }
 
-  function sweepToken(address token, uint256 amountMinimum, address recipient) public payable {
+  function sweepToken(address token, uint256 amountMinimum, address recipient) public {
     uint256 balanceToken = Balance.balance(token);
     if (balanceToken < amountMinimum) revert InsufficientOutputError();
 

--- a/src/periphery/SelfPermit.sol
+++ b/src/periphery/SelfPermit.sol
@@ -16,7 +16,7 @@ abstract contract SelfPermit is ISelfPermit {
   /// @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`
   /// @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`
   /// @param s Must produce valid secp256k1 signature from the holder along with `r` and `v`
-  function selfPermit(address token, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external payable {
+  function selfPermit(address token, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external {
     IERC20Permit(token).permit(msg.sender, address(this), value, deadline, v, r, s);
   }
 
@@ -37,7 +37,6 @@ abstract contract SelfPermit is ISelfPermit {
     bytes32 s
   )
     external
-    payable
   {
     IERC20PermitAllowed(token).permit(msg.sender, address(this), nonce, expiry, true, v, r, s);
   }

--- a/src/periphery/interfaces/ISelfPermit.sol
+++ b/src/periphery/interfaces/ISelfPermit.sol
@@ -10,7 +10,7 @@ interface ISelfPermit {
   /// @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`
   /// @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`
   /// @param s Must produce valid secp256k1 signature from the holder along with `r` and `v`
-  function selfPermit(address token, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external payable;
+  function selfPermit(address token, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
 
   /// @notice Permits this contract to spend the sender's tokens for permit signatures that have the `allowed` parameter
   /// @dev The `owner` is always msg.sender and the `spender` is always address(this)
@@ -28,6 +28,5 @@ interface ISelfPermit {
     bytes32 r,
     bytes32 s
   )
-    external
-    payable;
+    external;
 }


### PR DESCRIPTION
This PR addresses an issue where several functions across multiple contracts are marked with the payable modifier despite not utilizing the msg.value field. To avoid someone sending ether with their transactions, we removed payable from the following:

- `LiquidityManager.removeLiquidity`
- `LiquidityManager.collect`
- `SelfPermit.selfPermit`
- `SelfPermit.selfPermitAllowed`
- `Payment.unwrapETH`
- `Payment.sweepToken`
- `LendgineRouter.burn`