### PR TITLE
Rl/lendgine

### DIFF
--- a/lib/create3-factory/lib/solmate/package-lock.json
+++ b/lib/create3-factory/lib/solmate/package-lock.json
@@ -14,8 +14,8 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "version": ">=5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
       "dev": true
     },
@@ -112,7 +112,7 @@
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": ">=5.0.1"
       }
     },
     "yallist": {

--- a/script/SetupLocal.s.sol
+++ b/script/SetupLocal.s.sol
@@ -65,9 +65,9 @@ contract SetupLocalScript is Script {
     );
 
     // deploy new lendgines
-    console2.log("usdc/weth lendgine: ", factory.createLendgine(usdc, weth, 6, 18, usdcWethBound));
-    console2.log("weth/uni lendgine: ", factory.createLendgine(weth, uni, 18, 18, wethUniBound));
-    console2.log("uni/weth lendgine: ", factory.createLendgine(uni, weth, 18, 18, uniWethBound));
+    console2.log("usdc/weth lendgine: ", factory.createLendgine(usdc, weth, usdcWethBound));
+    console2.log("weth/uni lendgine: ", factory.createLendgine(weth, uni, wethUniBound));
+    console2.log("uni/weth lendgine: ", factory.createLendgine(uni, weth, uniWethBound));
 
     // mint tokens to addr
     IWETH9(weth).deposit{ value: 100 ether }();

--- a/src/core/Factory.sol
+++ b/src/core/Factory.sol
@@ -2,88 +2,80 @@
 pragma solidity ^0.8.4;
 
 import { Lendgine } from "./Lendgine.sol";
-
 import { IFactory } from "./interfaces/IFactory.sol";
 
 contract Factory is IFactory {
-  /*//////////////////////////////////////////////////////////////
+
+    /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
 
-  event LendgineCreated(
-    address indexed token0,
-    address indexed token1,
-    uint256 token0Exp,
-    uint256 token1Exp,
-    uint256 indexed strike,
-    address lendgine
-  );
+    event LendgineCreated(
+        address indexed token0,
+        address indexed token1,
+        uint256 indexed strike,
+        address lendgine
+    );
 
-  /*//////////////////////////////////////////////////////////////
+    /*//////////////////////////////////////////////////////////////
                                  ERRORS
     //////////////////////////////////////////////////////////////*/
 
-  error SameTokenError();
+    error SameTokenError();
+    error ZeroAddressError();
+    error DeployedError();
 
-  error ZeroAddressError();
-
-  error DeployedError();
-
-  error ScaleError();
-
-  /*//////////////////////////////////////////////////////////////
+    /*//////////////////////////////////////////////////////////////
                             FACTORY STORAGE
     //////////////////////////////////////////////////////////////*/
 
-  /// @inheritdoc IFactory
-  mapping(address => mapping(address => mapping(uint256 => mapping(uint256 => mapping(uint256 => address)))))
-    public
-    override getLendgine;
+    /// @inheritdoc IFactory
+    mapping(address => mapping(address => mapping(uint256 => address)))
+        public
+        override getLendgine;
 
-  /*//////////////////////////////////////////////////////////////
+    /*//////////////////////////////////////////////////////////////
                         TEMPORARY DEPLOY STORAGE
     //////////////////////////////////////////////////////////////*/
 
-  struct Parameters {
-    address token0;
-    address token1;
-    uint128 token0Exp;
-    uint128 token1Exp;
-    uint256 strike;
-  }
+    struct Parameters {
+        address token0;
+        address token1;
+        uint256 strike;
+    }
 
-  /// @inheritdoc IFactory
-  Parameters public override parameters;
+    /// @inheritdoc IFactory
+    Parameters public override parameters;
 
-  /*//////////////////////////////////////////////////////////////
+    /*//////////////////////////////////////////////////////////////
                               FACTORY LOGIC
     //////////////////////////////////////////////////////////////*/
 
-  /// @inheritdoc IFactory
-  function createLendgine(
-    address token0,
-    address token1,
-    uint8 token0Exp,
-    uint8 token1Exp,
-    uint256 strike
-  )
-    external
-    override
-    returns (address lendgine)
-  {
-    if (token0 == token1) revert SameTokenError();
-    if (token0 == address(0) || token1 == address(0)) revert ZeroAddressError();
-    if (getLendgine[token0][token1][token0Exp][token1Exp][strike] != address(0)) revert DeployedError();
-    if (token0Exp > 18 || token0Exp < 6 || token1Exp > 18 || token1Exp < 6) revert ScaleError();
+    /// @inheritdoc IFactory
+    function createLendgine(
+        address token0,
+        address token1,
+        uint256 strike
+    )
+        external
+        override
+        returns (address lendgine)
+    {
+        if (token0 == token1) revert SameTokenError();
+        if (token0 == address(0) || token1 == address(0)) revert ZeroAddressError();
+        if (getLendgine[token0][token1][strike] != address(0)) revert DeployedError();
 
-    parameters =
-      Parameters({ token0: token0, token1: token1, token0Exp: token0Exp, token1Exp: token1Exp, strike: strike });
+        parameters = Parameters({
+            token0: token0,
+            token1: token1,
+            strike: strike
+        });
 
-    lendgine = address(new Lendgine{ salt: keccak256(abi.encode(token0, token1, token0Exp, token1Exp, strike)) }());
+        lendgine = address(new Lendgine{ salt: keccak256(abi.encode(token0, token1, strike)) }());
 
-    delete parameters;
+        delete parameters;
 
-    getLendgine[token0][token1][token0Exp][token1Exp][strike] = lendgine;
-    emit LendgineCreated(token0, token1, token0Exp, token1Exp, strike, lendgine);
-  }
+        getLendgine[token0][token1][strike] = lendgine;
+        emit LendgineCreated(token0, token1, strike, lendgine);
+    }
 }

--- a/src/core/ImmutableState.sol
+++ b/src/core/ImmutableState.sol
@@ -21,7 +21,7 @@ abstract contract ImmutableState is IImmutableState {
   constructor() {
     factory = msg.sender;
 
-    (token0, token1, strike) = Factory(msg.sender).parameters();
+    (token0, token1, strike, , ) = Factory(msg.sender).parameters();
 
   }
 }

--- a/src/core/ImmutableState.sol
+++ b/src/core/ImmutableState.sol
@@ -21,10 +21,7 @@ abstract contract ImmutableState is IImmutableState {
   constructor() {
     factory = msg.sender;
 
-    uint128 _token0Exp;
-    uint128 _token1Exp;
-
-    (token0, token1, _token0Exp, _token1Exp, strike) = Factory(msg.sender).parameters();
+    (token0, token1, strike) = Factory(msg.sender).parameters();
 
   }
 }

--- a/src/core/Lendgine.sol
+++ b/src/core/Lendgine.sol
@@ -15,7 +15,9 @@ import { SafeTransferLib } from "../libraries/SafeTransferLib.sol";
 import { SafeCast } from "../libraries/SafeCast.sol";
 import { UD60x18, ud, mul, div, pow, sub } from "@prb/math/src/UD60x18.sol";
 
-
+/// @title Lending and borrowing of CFMMs
+/// @author Robert Leifke
+/// @notice Change accounting logic
 contract Lendgine is ERC20, JumpRate, Pair, ILendgine {
   using Position for mapping(address => Position.Info);
   using Position for Position.Info;

--- a/src/core/interfaces/IERC20.sol
+++ b/src/core/interfaces/IERC20.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity >=0.5.0;
+
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+
+    function balanceOf(address account) external view returns (uint256);
+
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) external returns (bool);
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    function decimals() external view returns (uint8);
+}

--- a/src/core/interfaces/IFactory.sol
+++ b/src/core/interfaces/IFactory.sol
@@ -2,40 +2,35 @@
 pragma solidity >=0.5.0;
 
 /// @notice Manages the recording and creation of Numo markets
-/// @author Kyle Scott and Robert Leifke
-/// @author Modified from Uniswap (https://github.com/Uniswap/v2-core/blob/master/contracts/UniswapV2Factory.sol)
+/// @dev Modified from Uniswap (https://github.com/Uniswap/v2-core/blob/master/contracts/UniswapV2Factory.sol)
 /// and Primitive (https://github.com/primitivefinance/rmm-core/blob/main/contracts/PrimitiveFactory.sol)
 interface IFactory {
-  /// @notice Returns the lendgine address for a given pair of tokens and upper bound
-  /// @dev returns address 0 if it doesn't exist
-  function getLendgine(
-    address token0,
-    address token1,
-    uint256 token0Exp,
-    uint256 token1Exp,
-    uint256 strike
-  )
-    external
-    view
-    returns (address lendgine);
+    /// @notice Returns the lendgine address for a given pair of tokens and upper bound
+    /// @dev returns address 0 if it doesn't exist
+    function getLendgine(
+        address token0,
+        address token1,
+        uint256 strike
+    )
+        external
+        view
+        returns (address lendgine);
 
-  /// @notice Get the parameters to be used in constructing the lendgine, set
-  /// transiently during lendgine creation
-  /// @dev Called by the immutable state constructor to fetch the parameters of the lendgine
-  function parameters()
-    external
-    view
-    returns (address token0, address token1, uint128 token0Exp, uint128 token1Exp, uint256 strike);
+    /// @notice Get the parameters to be used in constructing the lendgine, set
+    /// transiently during lendgine creation
+    /// @dev Called by the immutable state constructor to fetch the parameters of the lendgine
+    function parameters()
+        external
+        view
+        returns (address token0, address token1, uint256 strike);
 
-  /// @notice Deploys a lendgine contract by transiently setting the parameters storage slots
-  /// and clearing it after the lendgine has been deployed
-  function createLendgine(
-    address token0,
-    address token1,
-    uint8 token0Exp,
-    uint8 token1Exp,
-    uint256 strike
-  )
-    external
-    returns (address);
+    /// @notice Deploys a lendgine contract by transiently setting the parameters storage slots
+    /// and clearing it after the lendgine has been deployed
+    function createLendgine(
+        address token0,
+        address token1,
+        uint256 strike
+    )
+        external
+        returns (address);
 }

--- a/src/core/interfaces/IFactory.sol
+++ b/src/core/interfaces/IFactory.sol
@@ -22,7 +22,7 @@ interface IFactory {
     function parameters()
         external
         view
-        returns (address token0, address token1, uint256 strike);
+        returns (address token0, address token1, uint256 strike, uint8 token0Decimals, uint8 token1Decimals);
 
     /// @notice Deploys a lendgine contract by transiently setting the parameters storage slots
     /// and clearing it after the lendgine has been deployed

--- a/src/core/interfaces/IImmutableState.sol
+++ b/src/core/interfaces/IImmutableState.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity >=0.5.0;
 
-/// @notice Immutable state interface
+/// @title Immutable state interface
 /// @author Kyle Scott and Robert Leifke
 interface IImmutableState {
   /// @notice The contract that deployed the lendgine

--- a/src/periphery/LiquidityManager.sol
+++ b/src/periphery/LiquidityManager.sol
@@ -4,248 +4,220 @@ pragma solidity ^0.8.4;
 import { Multicall } from "./Multicall.sol";
 import { Payment } from "./Payment.sol";
 import { SelfPermit } from "./SelfPermit.sol";
-
 import { ILendgine } from "../core/interfaces/ILendgine.sol";
 import { IPairMintCallback } from "../core/interfaces/callback/IPairMintCallback.sol";
-
 import { FullMath } from "../libraries/FullMath.sol";
 import { LendgineAddress } from "./libraries/LendgineAddress.sol";
 
-/// @notice Manages liquidity provider positions
-/// @author Kyle Scott and Robert Leifke
+
 contract LiquidityManager is Multicall, Payment, SelfPermit, IPairMintCallback {
-  /*//////////////////////////////////////////////////////////////
+    /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
-  event AddLiquidity(
-    address indexed from,
-    address indexed lendgine,
-    uint256 liquidity,
-    uint256 size,
-    uint256 amount0,
-    uint256 amount1,
-    address indexed to
-  );
+    event AddLiquidity(
+        address indexed from,
+        address indexed lendgine,
+        uint256 liquidity,
+        uint256 size,
+        uint256 amount0,
+        uint256 amount1,
+        address indexed to
+    );
 
-  event RemoveLiquidity(
-    address indexed from,
-    address indexed lendgine,
-    uint256 liquidity,
-    uint256 size,
-    uint256 amount0,
-    uint256 amount1,
-    address indexed to
-  );
+    event RemoveLiquidity(
+        address indexed from,
+        address indexed lendgine,
+        uint256 liquidity,
+        uint256 size,
+        uint256 amount0,
+        uint256 amount1,
+        address indexed to
+    );
 
-  event Collect(address indexed from, address indexed lendgine, uint256 amount, address indexed to);
+    event Collect(address indexed from, address indexed lendgine, uint256 amount, address indexed to);
 
-  /*//////////////////////////////////////////////////////////////
+    /*//////////////////////////////////////////////////////////////
                                  ERRORS
     //////////////////////////////////////////////////////////////*/
+    error LivelinessError();
+    error AmountError();
+    error ValidationError();
+    error PositionInvalidError();
+    error CollectError();
 
-  error LivelinessError();
-
-  error AmountError();
-
-  error ValidationError();
-
-  error PositionInvalidError();
-
-  error CollectError();
-
-  /*//////////////////////////////////////////////////////////////
+    /*//////////////////////////////////////////////////////////////
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
+    address public immutable factory;
 
-  address public immutable factory;
-
-  struct Position {
-    uint256 size;
-    uint256 rewardPerPositionPaid;
-    uint256 tokensOwed;
-  }
-
-  /// @notice Owner to lendgine to position
-  mapping(address => mapping(address => Position)) public positions;
-
-  /*//////////////////////////////////////////////////////////////
+    /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
-
-  constructor(address _factory, address _weth) Payment(_weth) {
-    factory = _factory;
-  }
-
-  /*//////////////////////////////////////////////////////////////
-                           LIVELINESS MODIFIER
-    //////////////////////////////////////////////////////////////*/
-
-  modifier checkDeadline(uint256 deadline) {
-    if (deadline < block.timestamp) revert LivelinessError();
-    _;
-  }
-
-  /*//////////////////////////////////////////////////////////////
-                                CALLBACK
-    //////////////////////////////////////////////////////////////*/
-
-  struct PairMintCallbackData {
-    address token0;
-    address token1;
-    uint256 token0Exp;
-    uint256 token1Exp;
-    uint256 strike;
-    uint256 amount0;
-    uint256 amount1;
-    address payer;
-  }
-
-  /// @notice callback that sends the underlying tokens for the specified amount of liquidity shares
-  function pairMintCallback(uint256, bytes calldata data) external {
-    PairMintCallbackData memory decoded = abi.decode(data, (PairMintCallbackData));
-
-    address lendgine = LendgineAddress.computeAddress(
-      factory, decoded.token0, decoded.token1, decoded.token0Exp, decoded.token1Exp, decoded.strike
-    );
-    if (lendgine != msg.sender) revert ValidationError();
-
-    if (decoded.amount0 > 0) pay(decoded.token0, decoded.payer, msg.sender, decoded.amount0);
-    if (decoded.amount1 > 0) pay(decoded.token1, decoded.payer, msg.sender, decoded.amount1);
-  }
-
-  /*//////////////////////////////////////////////////////////////
-                        LIQUIDITY MANAGER LOGIC
-    //////////////////////////////////////////////////////////////*/
-
-  struct AddLiquidityParams {
-    address token0;
-    address token1;
-    uint256 token0Exp;
-    uint256 token1Exp;
-    uint256 strike;
-    uint256 liquidity;
-    uint256 amount0Min;
-    uint256 amount1Min;
-    uint256 sizeMin;
-    address recipient;
-    uint256 deadline;
-  }
-
-  /// @notice Add liquidity to a liquidity position
-  function addLiquidity(AddLiquidityParams calldata params) external payable checkDeadline(params.deadline) {
-    address lendgine = LendgineAddress.computeAddress(
-      factory, params.token0, params.token1, params.token0Exp, params.token1Exp, params.strike
-    );
-
-    uint256 r0 = ILendgine(lendgine).reserve0();
-    uint256 r1 = ILendgine(lendgine).reserve1();
-    uint256 totalLiquidity = ILendgine(lendgine).totalLiquidity();
-
-    uint256 amount0;
-    uint256 amount1;
-
-    if (totalLiquidity == 0) {
-      amount0 = params.amount0Min;
-      amount1 = params.amount1Min;
-    } else {
-      amount0 = FullMath.mulDivRoundingUp(params.liquidity, r0, totalLiquidity);
-      amount1 = FullMath.mulDivRoundingUp(params.liquidity, r1, totalLiquidity);
+    constructor(address _factory, address _weth) Payment(_weth) {
+        factory = _factory;
     }
 
-    if (amount0 < params.amount0Min || amount1 < params.amount1Min) revert AmountError();
+    /*//////////////////////////////////////////////////////////////
+                           LIVELINESS MODIFIER
+    //////////////////////////////////////////////////////////////*/
+    modifier checkDeadline(uint256 deadline) {
+        if (deadline < block.timestamp) revert LivelinessError();
+        _;
+    }
 
-    uint256 size = ILendgine(lendgine).deposit(
-      address(this),
-      params.liquidity,
-      abi.encode(
-        PairMintCallbackData({
-          token0: params.token0,
-          token1: params.token1,
-          token0Exp: params.token0Exp,
-          token1Exp: params.token1Exp,
-          strike: params.strike,
-          amount0: amount0,
-          amount1: amount1,
-          payer: msg.sender
-        })
-      )
-    );
-    if (size < params.sizeMin) revert AmountError();
+    /*//////////////////////////////////////////////////////////////
+                                CALLBACK
+    //////////////////////////////////////////////////////////////*/
+    struct PairMintCallbackData {
+        address token0;
+        address token1;
+        uint256 token0Exp;
+        uint256 token1Exp;
+        uint256 strike;
+        uint256 amount0;
+        uint256 amount1;
+        address payer;
+    }
 
-    Position memory position = positions[params.recipient][lendgine]; // SLOAD
+    /// @notice callback that sends the underlying tokens for the specified amount of liquidity shares
+    function pairMintCallback(uint256, bytes calldata data) external {
+        PairMintCallbackData memory decoded = abi.decode(data, (PairMintCallbackData));
 
-    (, uint256 rewardPerPositionPaid,) = ILendgine(lendgine).positions(address(this));
-    position.tokensOwed += FullMath.mulDiv(position.size, rewardPerPositionPaid - position.rewardPerPositionPaid, 1e18);
-    position.rewardPerPositionPaid = rewardPerPositionPaid;
-    position.size += size;
+        address lendgine = LendgineAddress.computeAddress(
+            factory, decoded.token0, decoded.token1, decoded.token0Exp, decoded.token1Exp, decoded.strike
+        );
+        if (lendgine != msg.sender) revert ValidationError();
 
-    positions[params.recipient][lendgine] = position; // SSTORE
+        if (decoded.amount0 > 0) pay(decoded.token0, decoded.payer, msg.sender, decoded.amount0);
+        if (decoded.amount1 > 0) pay(decoded.token1, decoded.payer, msg.sender, decoded.amount1);
+    }
 
-    emit AddLiquidity(msg.sender, lendgine, params.liquidity, size, amount0, amount1, params.recipient);
-  }
+    /*//////////////////////////////////////////////////////////////
+                        LIQUIDITY MANAGER LOGIC
+    //////////////////////////////////////////////////////////////*/
+    struct AddLiquidityParams {
+        address token0;
+        address token1;
+        uint256 token0Exp;
+        uint256 token1Exp;
+        uint256 strike;
+        uint256 liquidity;
+        uint256 amount0Min;
+        uint256 amount1Min;
+        uint256 sizeMin;
+        address recipient;
+        uint256 deadline;
+    }
 
-  struct RemoveLiquidityParams {
-    address token0;
-    address token1;
-    uint256 token0Exp;
-    uint256 token1Exp;
-    uint256 strike;
-    uint256 size;
-    uint256 amount0Min;
-    uint256 amount1Min;
-    address recipient;
-    uint256 deadline;
-  }
+    /// @notice Add liquidity to a liquidity position
+    function addLiquidity(AddLiquidityParams calldata params) external payable checkDeadline(params.deadline) {
+        address lendgine = LendgineAddress.computeAddress(
+            factory, params.token0, params.token1, params.token0Exp, params.token1Exp, params.strike
+        );
 
-  /// @notice Removes from a liquidity position
-  function removeLiquidity(RemoveLiquidityParams calldata params) external checkDeadline(params.deadline) {
-    address lendgine = LendgineAddress.computeAddress(
-      factory, params.token0, params.token1, params.token0Exp, params.token1Exp, params.strike
-    );
+        uint256 r0 = ILendgine(lendgine).reserve0();
+        uint256 r1 = ILendgine(lendgine).reserve1();
+        uint256 totalLiquidity = ILendgine(lendgine).totalLiquidity();
 
-    address recipient = params.recipient == address(0) ? address(this) : params.recipient;
+        uint256 amount0;
+        uint256 amount1;
 
-    (uint256 amount0, uint256 amount1, uint256 liquidity) = ILendgine(lendgine).withdraw(recipient, params.size);
-    if (amount0 < params.amount0Min || amount1 < params.amount1Min) revert AmountError();
+        if (totalLiquidity == 0) {
+            amount0 = params.amount0Min;
+            amount1 = params.amount1Min;
+        } else {
+            amount0 = FullMath.mulDivRoundingUp(params.liquidity, r0, totalLiquidity);
+            amount1 = FullMath.mulDivRoundingUp(params.liquidity, r1, totalLiquidity);
+        }
 
-    Position memory position = positions[msg.sender][lendgine]; // SLOAD
+        if (amount0 < params.amount0Min || amount1 < params.amount1Min) revert AmountError();
 
-    (, uint256 rewardPerPositionPaid,) = ILendgine(lendgine).positions(address(this));
-    position.tokensOwed += FullMath.mulDiv(position.size, rewardPerPositionPaid - position.rewardPerPositionPaid, 1e18);
-    position.rewardPerPositionPaid = rewardPerPositionPaid;
-    position.size -= params.size;
+        uint256 size = ILendgine(lendgine).deposit(
+            params.recipient,
+            params.liquidity,
+            abi.encode(
+                PairMintCallbackData({
+                    token0: params.token0,
+                    token1: params.token1,
+                    token0Exp: params.token0Exp,
+                    token1Exp: params.token1Exp,
+                    strike: params.strike,
+                    amount0: amount0,
+                    amount1: amount1,
+                    payer: msg.sender
+                })
+            )
+        );
+        if (size < params.sizeMin) revert AmountError();
 
-    positions[msg.sender][lendgine] = position; // SSTORE
+        emit AddLiquidity(msg.sender, lendgine, params.liquidity, size, amount0, amount1, params.recipient);
+    }
 
-    emit RemoveLiquidity(msg.sender, lendgine, liquidity, params.size, amount0, amount1, recipient);
-  }
+    struct RemoveLiquidityParams {
+        address token0;
+        address token1;
+        uint256 token0Exp;
+        uint256 token1Exp;
+        uint256 strike;
+        uint256 size;
+        uint256 amount0Min;
+        uint256 amount1Min;
+        address recipient;
+        uint256 deadline;
+    }
 
-  struct CollectParams {
-    address lendgine;
-    address recipient;
-    uint256 amountRequested;
-  }
+    /// @notice Removes from a liquidity position
+    function removeLiquidity(RemoveLiquidityParams calldata params) external checkDeadline(params.deadline) {
+        address lendgine = LendgineAddress.computeAddress(
+            factory, params.token0, params.token1, params.token0Exp, params.token1Exp, params.strike
+        );
 
-  /// @notice Collects interest owed to the callers liqudity position
-  function collect(CollectParams calldata params) external returns (uint256 amount) {
-    ILendgine(params.lendgine).accruePositionInterest();
+        address recipient = params.recipient == address(0) ? msg.sender : params.recipient;
 
-    address recipient = params.recipient == address(0) ? address(this) : params.recipient;
+        (uint256 amount0, uint256 amount1, uint256 liquidity) = ILendgine(lendgine).withdraw(recipient, params.size);
+        if (amount0 < params.amount0Min || amount1 < params.amount1Min) revert AmountError();
 
-    Position memory position = positions[msg.sender][params.lendgine]; // SLOAD
+        emit RemoveLiquidity(msg.sender, lendgine, liquidity, params.size, amount0, amount1, recipient);
+    }
 
-    (, uint256 rewardPerPositionPaid,) = ILendgine(params.lendgine).positions(address(this));
-    position.tokensOwed += FullMath.mulDiv(position.size, rewardPerPositionPaid - position.rewardPerPositionPaid, 1e18);
-    position.rewardPerPositionPaid = rewardPerPositionPaid;
+    struct CollectParams {
+        address lendgine;
+        address recipient;
+        uint256 amountRequested;
+    }
 
-    amount = params.amountRequested > position.tokensOwed ? position.tokensOwed : params.amountRequested;
-    position.tokensOwed -= amount;
+    /// @notice Collects interest owed to the caller's liquidity position
+    function collect(CollectParams calldata params) external returns (uint256 amount) {
+        ILendgine(params.lendgine).accruePositionInterest();
 
-    positions[msg.sender][params.lendgine] = position; // SSTORE
+        address recipient = params.recipient == address(0) ? msg.sender : params.recipient;
 
-    uint256 collectAmount = ILendgine(params.lendgine).collect(recipient, amount);
-    if (collectAmount != amount) revert CollectError(); // extra check for safety
+        amount = ILendgine(params.lendgine).collect(msg.sender, params.amountRequested);
 
-    emit Collect(msg.sender, params.lendgine, amount, recipient);
-  }
+        emit Collect(msg.sender, params.lendgine, amount, recipient);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         MINT AND BURN WRAPPERS
+    //////////////////////////////////////////////////////////////*/
+    struct MintParams {
+        address recipient;
+        uint256 collateral;
+        bytes data;
+    }
+
+    /// @notice Mint liquidity provider shares
+    function mint(MintParams calldata params) external returns (uint256 shares) {
+        shares = ILendgine(factory).mint(params.recipient, params.collateral, params.data);
+    }
+
+    struct BurnParams {
+        address recipient;
+        bytes data;
+    }
+
+    /// @notice Burn liquidity provider shares
+    function burn(BurnParams calldata params) external returns (uint256 collateral) {
+        collateral = ILendgine(factory).burn(params.recipient, params.data);
+    }
 }

--- a/test/FactoryTest.t.sol
+++ b/test/FactoryTest.t.sol
@@ -1,31 +1,31 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.19;
 
-import { Factory } from "../src/core/Factory.sol";
-import { Lendgine } from "../src/core/Lendgine.sol";
-import { Test } from "forge-std/Test.sol";
+// import { Factory } from "../src/core/Factory.sol";
+// import { Lendgine } from "../src/core/Lendgine.sol";
+// import { Test } from "forge-std/Test.sol";
 
-import { LendgineAddress } from "../src/periphery/libraries/LendgineAddress.sol";
+// import { LendgineAddress } from "../src/periphery/libraries/LendgineAddress.sol";
 
-contract FactoryTest is Test {
-  event LendgineCreated(
-    address indexed token0,
-    address indexed token1,
-    uint256 indexed strike,
-    address lendgine
-  );
+// contract FactoryTest is Test {
+//   event LendgineCreated(
+//     address indexed token0,
+//     address indexed token1,
+//     uint256 indexed strike,
+//     address lendgine
+//   );
 
-  Factory public factory;
+//   Factory public factory;
 
-  function setUp() external {
-    factory = new Factory();
-  }
+//   function setUp() external {
+//     factory = new Factory();
+//   }
 
-  function testGetLendgine() external {
-    address lendgine = factory.createLendgine(address(1), address(2), 1e18);
+//   function testGetLendgine() external {
+//     address lendgine = factory.createLendgine(address(1), address(2), 1e18);
 
-    assertEq(lendgine, factory.getLendgine(address(1), address(2), 1e18));
-  }
+//     assertEq(lendgine, factory.getLendgine(address(1), address(2), 1e18));
+//   }
 
 //   function testDeployAddress() external {
 //     address lendgineEstimate = LendgineAddress.computeAddress(address(factory), address(1), address(2), 18, 18, 1e18);
@@ -35,60 +35,60 @@ contract FactoryTest is Test {
 //     assertEq(lendgine, lendgineEstimate);
 //   }
 
-  function testSameTokenError() external {
-    vm.expectRevert(Factory.SameTokenError.selector);
-    factory.createLendgine(address(1), address(1), 1e18);
-  }
+//   function testSameTokenError() external {
+//     vm.expectRevert(Factory.SameTokenError.selector);
+//     factory.createLendgine(address(1), address(1), 1e18);
+//   }
 
-  function testZeroAddressError() external {
-    vm.expectRevert(Factory.ZeroAddressError.selector);
-    factory.createLendgine(address(0), address(1), 1e18);
+//   function testZeroAddressError() external {
+//     vm.expectRevert(Factory.ZeroAddressError.selector);
+//     factory.createLendgine(address(0), address(1), 1e18);
 
-    vm.expectRevert(Factory.ZeroAddressError.selector);
-    factory.createLendgine(address(1), address(0), 1e18);
-  }
+//     vm.expectRevert(Factory.ZeroAddressError.selector);
+//     factory.createLendgine(address(1), address(0), 1e18);
+//   }
 
-  function testDeployedError() external {
-    factory.createLendgine(address(1), address(2), 1e18);
+//   function testDeployedError() external {
+//     factory.createLendgine(address(1), address(2), 1e18);
 
-    vm.expectRevert(Factory.DeployedError.selector);
-    factory.createLendgine(address(1), address(2), 1e18);
-  }
+//     vm.expectRevert(Factory.DeployedError.selector);
+//     factory.createLendgine(address(1), address(2), 1e18);
+//   }
 
-  function helpParametersZero() private view {
-    (address token0, address token1, uint256 strike) =
-      factory.parameters();
+//   function helpParametersZero() private view {
+//     (address token0, address token1, uint256 strike) =
+//       factory.parameters();
 
-    assertEq(address(0), token0);
-    assertEq(address(0), token1);
-    assertEq(0, strike);
-  }
+//     assertEq(address(0), token0);
+//     assertEq(address(0), token1);
+//     assertEq(0, strike);
+//   }
 
-  function testParameters() external {
-    helpParametersZero();
+//   function testParameters() external {
+//     helpParametersZero();
 
-    factory.createLendgine(address(1), address(2), 1e18);
+//     factory.createLendgine(address(1), address(2), 1e18);
 
-    helpParametersZero();
-  }
+//     helpParametersZero();
+//   }
 
-  function testEmit() external {
-    address lendgineEstimate = address(
-      uint160(
-        uint256(
-          keccak256(
-            abi.encodePacked(
-              hex"ff",
-              address(factory),
-              keccak256(abi.encode(address(1), address(2), 1e18)),
-              keccak256(type(Lendgine).creationCode)
-            )
-          )
-        )
-      )
-    );
-    vm.expectEmit(true, true, true, true, address(factory));
-    emit LendgineCreated(address(1), address(2), 1e18, lendgineEstimate);
-    factory.createLendgine(address(1), address(2), 1e18);
-  }
-}
+//   function testEmit() external {
+//     address lendgineEstimate = address(
+//       uint160(
+//         uint256(
+//           keccak256(
+//             abi.encodePacked(
+//               hex"ff",
+//               address(factory),
+//               keccak256(abi.encode(address(1), address(2), 1e18)),
+//               keccak256(type(Lendgine).creationCode)
+//             )
+//           )
+//         )
+//       )
+//     );
+//     vm.expectEmit(true, true, true, true, address(factory));
+//     emit LendgineCreated(address(1), address(2), 1e18, lendgineEstimate);
+//     factory.createLendgine(address(1), address(2), 1e18);
+//   }
+// }

--- a/test/FactoryTest.t.sol
+++ b/test/FactoryTest.t.sol
@@ -1,98 +1,94 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.0;
 
-// import { Factory } from "../src/core/Factory.sol";
-// import { Lendgine } from "../src/core/Lendgine.sol";
-// import { Test } from "forge-std/Test.sol";
+import { Factory } from "../src/core/Factory.sol";
+import { Lendgine } from "../src/core/Lendgine.sol";
+import { Test } from "forge-std/Test.sol";
 
-// import { LendgineAddress } from "../src/periphery/libraries/LendgineAddress.sol";
+import { LendgineAddress } from "../src/periphery/libraries/LendgineAddress.sol";
 
-// contract FactoryTest is Test {
-//   event LendgineCreated(
-//     address indexed token0,
-//     address indexed token1,
-//     uint256 token0Scale,
-//     uint256 token1Scale,
-//     uint256 indexed strike,
-//     address lendgine
-//   );
+contract FactoryTest is Test {
+  event LendgineCreated(
+    address indexed token0,
+    address indexed token1,
+    uint256 indexed strike,
+    address lendgine
+  );
 
-//   Factory public factory;
+  Factory public factory;
 
-//   function setUp() external {
-//     factory = new Factory();
-//   }
+  function setUp() external {
+    factory = new Factory();
+  }
 
-//   function testGetLendgine() external {
-//     address lendgine = factory.createLendgine(address(1), address(2), 18, 18, 1e18);
+  function testGetLendgine() external {
+    address lendgine = factory.createLendgine(address(1), address(2), 1e18);
 
-//     assertEq(lendgine, factory.getLendgine(address(1), address(2), 18, 18, 1e18));
-//   }
+    assertEq(lendgine, factory.getLendgine(address(1), address(2), 1e18));
+  }
 
 //   function testDeployAddress() external {
 //     address lendgineEstimate = LendgineAddress.computeAddress(address(factory), address(1), address(2), 18, 18, 1e18);
 
-//     address lendgine = factory.createLendgine(address(1), address(2), 18, 18, 1e18);
+//     address lendgine = factory.createLendgine(address(1), address(2), 1e18);
 
 //     assertEq(lendgine, lendgineEstimate);
 //   }
 
-//   function testSameTokenError() external {
-//     vm.expectRevert(Factory.SameTokenError.selector);
-//     factory.createLendgine(address(1), address(1), 18, 18, 1e18);
-//   }
+  function testSameTokenError() external {
+    vm.expectRevert(Factory.SameTokenError.selector);
+    factory.createLendgine(address(1), address(1), 1e18);
+  }
 
-//   function testZeroAddressError() external {
-//     vm.expectRevert(Factory.ZeroAddressError.selector);
-//     factory.createLendgine(address(0), address(1), 18, 18, 1e18);
+  function testZeroAddressError() external {
+    vm.expectRevert(Factory.ZeroAddressError.selector);
+    factory.createLendgine(address(0), address(1), 1e18);
 
-//     vm.expectRevert(Factory.ZeroAddressError.selector);
-//     factory.createLendgine(address(1), address(0), 18, 18, 1e18);
-//   }
+    vm.expectRevert(Factory.ZeroAddressError.selector);
+    factory.createLendgine(address(1), address(0), 1e18);
+  }
 
-//   function testDeployedError() external {
-//     factory.createLendgine(address(1), address(2), 18, 18, 1e18);
+  function testDeployedError() external {
+    factory.createLendgine(address(1), address(2), 1e18);
 
-//     vm.expectRevert(Factory.DeployedError.selector);
-//     factory.createLendgine(address(1), address(2), 18, 18, 1e18);
-//   }
+    vm.expectRevert(Factory.DeployedError.selector);
+    factory.createLendgine(address(1), address(2), 1e18);
+  }
 
-//   function helpParametersZero() private view {
-//     (address token0, address token1, uint256 token0Scale, uint256 token1Scale, uint256 strike) =
-//       factory.parameters();
+  function helpParametersZero() private view {
+    (address token0, address token1, uint256 strike) =
+      factory.parameters();
 
-//     assertEq(address(0), token0);
-//     assertEq(address(0), token1);
-//     assertEq(0, token0Scale);
-//     assertEq(0, token1Scale);
-//     assertEq(0, strike);
-//   }
+    assertEq(address(0), token0);
+    assertEq(address(0), token1);
+    assertEq(0, strike);
+  }
 
-//   function testParameters() external {
-//     helpParametersZero();
+  function testParameters() external {
+    helpParametersZero();
 
-//     factory.createLendgine(address(1), address(2), 18, 18, 1e18);
+    factory.createLendgine(address(1), address(2), 1e18);
 
-//     helpParametersZero();
-//   }
+    helpParametersZero();
+  }
 
-//   function testEmit() external {
-//     address lendgineEstimate = address(
-//       uint160(
-//         uint256(
-//           keccak256(
-//             abi.encodePacked(
-//               hex"ff",
-//               address(factory),
-//               keccak256(abi.encode(address(1), address(2), 18, 18, 1e18)),
-//               keccak256(type(Lendgine).creationCode)
-//             )
-//           )
-//         )
-//       )
-//     );
-//     vm.expectEmit(true, true, true, true, address(factory));
-//     emit LendgineCreated(address(1), address(2), 18, 18, 1e18, lendgineEstimate);
-//     factory.createLendgine(address(1), address(2), 18, 18, 1e18);
-//   }
-// }
+  function testEmit() external {
+    address lendgineEstimate = address(
+      uint160(
+        uint256(
+          keccak256(
+            abi.encodePacked(
+              hex"ff",
+              address(factory),
+              keccak256(abi.encode(address(1), address(2), 1e18)),
+              keccak256(type(Lendgine).creationCode)
+            )
+          )
+        )
+      )
+    );
+    vm.expectEmit(true, true, true, true, address(factory));
+    emit LendgineCreated(address(1), address(2), 1e18, lendgineEstimate);
+    factory.createLendgine(address(1), address(2), 1e18);
+  }
+}

--- a/test/utils/TestHelper.sol
+++ b/test/utils/TestHelper.sol
@@ -12,9 +12,6 @@ pragma solidity ^0.8.0;
 //   MockERC20 public token0;
 //   MockERC20 public token1;
 
-//   uint8 public token0Scale;
-//   uint8 public token1Scale;
-
 //   uint256 public strike;
 
 //   Factory public factory;
@@ -33,10 +30,7 @@ pragma solidity ^0.8.0;
 //     alice = mkaddr("alice");
 //     dennis = mkaddr("dennis");
 
-//     token0Scale = 18;
-//     token1Scale = 18;
-
-//     strike = 5 * 1e18;
+//     strike = 2 * 1e18;
 //   }
 
 //   function _setUp() internal {


### PR DESCRIPTION
This PR fetches the correct decimals on `token0` and `token1` as well as gets rid of the position struct from `liquidityManager.sol` contract entirely. Thus reducing the attack surface area for the `lendgine.sol` contract. 